### PR TITLE
Update post_infra.yml - allow connection to highside

### DIFF
--- a/ansible/configs/ocp4-disconnected/post_infra.yml
+++ b/ansible/configs/ocp4-disconnected/post_infra.yml
@@ -176,7 +176,7 @@
             ansible_ssh_pass: "{{ user_password }}"
             ansible_sudo_pass: "{{ user_password }}"
             ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
-            ansible_ssh_common_args: "-i $HOME/.ssh/id_rsa -J lab-user@{{ cloudformation_out.stack_outputs.JumpInstancePublicIp }}"
+            ansible_ssh_common_args: '-o ProxyCommand="sshpass -p {{ user_password }} ssh lab-user@{{ cloudformation_out.stack_outputs.JumpInstancePublicIp }} -W {{ item.private_ip_address | default(item.private_dns_name) }}:22"'
           with_items: "{{ ec2_info['instances'] }}"
           when:
             - item.state.name != 'terminated'
@@ -184,37 +184,12 @@
           loop_control:
             label: "{{ item.tags.Name | default(item.private_dns_name) }}"
 
-        # building a ssh key for the execution environment to be able to ssh through jump host to highside
-        - name: make .ssh/ dir
-          ansible.builtin.file:
-            path: "$HOME/.ssh"
-            mode: "0700"
-            state: directory
-
-        - name: Generate keypair
-          command: /usr/bin/ssh-keygen -C 'EE jump host key' -q -N '' -f $HOME/.ssh/id_rsa
-
-        - name: Get public key
-          ansible.builtin.slurp:
-            src: $HOME/.ssh/id_rsa.pub
-          register: ee_pubkey
-
-        - name: Save pub keypair
-          set_fact:
-            ee_pubkey: "{{ ee_pubkey['content'] | b64decode }}"
-
 - name: Configure jump host
   hosts:
     - bastions
   become: false
   gather_facts: false
   tasks:
-    - name: Add our ee authorized key
-      ansible.posix.authorized_key:
-        user: lab-user
-        state: present
-        key: "{{ hostvars.localhost.ee_pubkey }}"
-
     - name: Generate keypair
       command: /usr/bin/ssh-keygen -C 'Lab Environment Jump Host Key' -q -N '' -f /home/lab-user/.ssh/id_rsa
 


### PR DESCRIPTION
Use `sshpass` and ProxyCommand to allow Ansible Controller to configure the "highside" instance via the "jump" instance

Working theory: The previous attempt to create an id_rsa key in the ExecutionEnvironment failed because a new container is used for every play of a playbook...

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
